### PR TITLE
V0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
-## 0.0.3
+## 0.0.5
+- Added deprecated warning for `require("textwire").load_highlights()` usage
+
+## 0.0.4
 - Changed the way you setup the plugin
 - Added LSP support

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Textwire
+Copyright (c) 2025 Sergey Chornenkyi (Serhii Cho)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lua/textwire/init.lua
+++ b/lua/textwire/init.lua
@@ -1,11 +1,23 @@
 local textwire = {}
 
+local deprecation_msg = [[
+textwire.load_highlights() is deprecated and will be removed in the next major
+version update. Use textwire.build() instead.
+
+Go into your plugins/textwire.lua config file and rename load_highlights()
+to build() to hide this warning message.
+]]
+
 --- Load the highlights (syntax highlighting) for Textwire.
 --- @return nil
 --- @deprecated This function is deprecated. Use `textwire.build()` instead.
 function textwire.load_highlights()
 	require("textwire.highlights").load()
-	require("textwire.lsp").load()
+
+	vim.notify(deprecation_msg, vim.log.levels.WARN, {
+		title = "Deprecation Warning",
+		timeout = 10000,
+	})
 end
 
 --- Load and install LSP server for Textwire.


### PR DESCRIPTION
- Added deprecated warning for `require("textwire").load_highlights()` usage