### PR TITLE
V0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Release Notes
-
-## 0.0.5
-- Added deprecated warning for `require("textwire").load_highlights()` usage
-
-## 0.0.4
-- Changed the way you setup the plugin
-- Added LSP support

--- a/doc/textwire.txt
+++ b/doc/textwire.txt
@@ -1,15 +1,45 @@
 ================================================================================
-INTRODUCTION                                                      textwire.nvim*
+INTRODUCTION                                                     *textwire.nvim*
 
-This plugin adds support for syntax highlighting for Textwire
-templating language for Go.
+This plugin adds support for syntax highlighting and LSP features such as
+autocomplete and hover for Textwire file in Neovim. It uses the
+Textwire LSP binary to provide LSP features and tree-sitter for syntax
+highlighting.
 
+  :h textwire
+  :h textwire.changelog
 
-textwire.load_highlights()                          *textwire.load_highlights()*
+textwire.load_highlights() DEPRECATED               *textwire.load_highlights()*
     Fetch recent highlight files from GitHub and insert them into queries in
     your Neovim's directory.
+
+    THIS FUNCTION IS DEPRECATED AND WILL BE REMOVED IN THE VERSION 1.0.0!
+    USE textwire.build() INSTEAD!
 
     Usage:
     >
     textwire.load_highlights()
 <
+
+textwire.build()                                              *textwire.build()*
+    Fetch recent highlight files from GitHub and insert them into queries in
+    your Neovim's directory. Also it will download the LSP binary and install it
+    locally to get LSP features for Textwire such as completion and hover.
+
+    Usage:
+    >
+    textwire.build()
+<
+
+================================================================================
+COMMANDS                                                     *textwire.commands*
+
+Below you can find the list of available commands for this plugin.
+
+:TextwireInstallLsp                                        *textwire.lsp.load()*
+    Install the Textwire LSP binary to your local machine depending on your
+    operating system. This command will run automatically on update of your
+    plugin if you have `require("textwire").build()` in your `build` callback.
+    Running this command will fetch the latest version of the LSP binary from
+    GitHub and download it to your machine to the Neovim directory depending on
+    your operating system.

--- a/doc/textwire_changelog.txt
+++ b/doc/textwire_changelog.txt
@@ -1,0 +1,29 @@
+================================================================================
+CHANGELOG                                                   *textwire.changelog*
+
+                                                          *textwire.changelog-1*
+
+Date: April 24, 2025
+PR: https://github.com/textwire/textwire.nvim/pull/1
+
+Contributions:
+1. Changed the way you setup the plugin.
+2. Added LSP support with autocomplete and hover feature.
+
+                                                          *textwire.changelog-2*
+
+Date: April 24, 2025
+PR: https://github.com/textwire/textwire.nvim/pull/2
+
+Contributions:
+1. Added deprecated warning for `require("textwire").load_highlights()` usage
+
+
+                                                          *textwire.changelog-3*
+
+Date: April 24, 2025
+PR: https://github.com/textwire/textwire.nvim/pull/2
+
+Contributions:
+1. Added more information to `:h textwire` command.
+2. Added `h textwire.changelog` command with the release notes.

--- a/doc/textwire_changelog.txt
+++ b/doc/textwire_changelog.txt
@@ -4,6 +4,7 @@ CHANGELOG                                                   *textwire.changelog*
                                                           *textwire.changelog-1*
 
 Date: April 24, 2025
+Version: 0.0.4
 PR: https://github.com/textwire/textwire.nvim/pull/1
 
 Contributions:
@@ -13,6 +14,7 @@ Contributions:
                                                           *textwire.changelog-2*
 
 Date: April 24, 2025
+Version: 0.0.5
 PR: https://github.com/textwire/textwire.nvim/pull/2
 
 Contributions:
@@ -22,6 +24,7 @@ Contributions:
                                                           *textwire.changelog-3*
 
 Date: April 24, 2025
+Version: 0.0.6
 PR: https://github.com/textwire/textwire.nvim/pull/2
 
 Contributions:


### PR DESCRIPTION
1. Added more information to `:h textwire` command.
2. Added `h textwire.changelog` command with the release notes.